### PR TITLE
Call through to [super mainViewDidLoad]

### DIFF
--- a/QSCommandLineToolPrefPane.m
+++ b/QSCommandLineToolPrefPane.m
@@ -40,6 +40,7 @@
 - (void)mainViewDidLoad{
 	[self populateFields];
 	[toolImageView setImage:[self paneIcon]];
+    [super mainViewDidLoad];
 }
 
 - (void) populateFields{


### PR DESCRIPTION
I'm currently fixing quicksilver/#999 by adding methods to `-[QSPreferencePane mainViewDidLoad]`. Plugins needs to call through to super in order for these changes to be present.
