### PR TITLE
update the tool’s install path

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>49</string>
+	<string>4B</string>
 	<key>NSPrincipalClass</key>
 	<string>QSCommandLineTool</string>
 	<key>QSLoadImmediately</key>
@@ -74,6 +74,11 @@ pbpaste | qs
 				<string>Command Line Tool</string>
 			</dict>
 		</dict>
+	</dict>
+	<key>QSRequirements</key>
+	<dict>
+		<key>version</key>
+		<string>4012</string>
 	</dict>
 </dict>
 </plist>

--- a/QSCommandLineTool.m
+++ b/QSCommandLineTool.m
@@ -30,7 +30,7 @@
 {
 	NSFileManager *manager = [NSFileManager defaultManager];
 	NSString *currentPath = [[NSBundle bundleForClass:[self class]]pathForResource:@"qs" ofType:@""];
-	NSString *installedPath = @"/usr/bin/qs";
+	NSString *installedPath = @"/usr/local/bin/qs";
 	if ([manager fileExistsAtPath:installedPath] && [manager contentsEqualAtPath:currentPath andPath:installedPath]) {
 		[self performSelectorOnMainThread:@selector(startToolConnection) withObject:nil waitUntilDone:NO];
 	} else {

--- a/QSCommandLineToolPrefPane.m
+++ b/QSCommandLineToolPrefPane.m
@@ -46,15 +46,17 @@
 	NSFileManager *manager = [NSFileManager defaultManager];
 	NSString *currentPath = [[NSBundle bundleForClass:[self class]]pathForResource:@"qs" ofType:@""];
 	NSString *installedPath = @"/usr/local/bin/qs";
+    NSString *status = [NSString stringWithFormat:@"Installed: %@", installedPath];
 	if ([manager fileExistsAtPath:installedPath]) {
 		if ([manager contentsEqualAtPath:currentPath andPath:installedPath]) {
-			[toolInstallStatus setStringValue:@"Installed"];
+			[toolInstallStatus setStringValue:status];
 			[self setToolCanBeInstalled:NO];
 		} else {
 			[toolInstallStatus setStringValue:@"Out of Date"];
 		}
 	} else {
-		[toolInstallStatus setStringValue:@"Not Installed"];
+        status = [NSString stringWithFormat:@"Not Installed: %@", installedPath];
+		[toolInstallStatus setStringValue:status];
 	}
 }
 

--- a/QSCommandLineToolPrefPane.m
+++ b/QSCommandLineToolPrefPane.m
@@ -45,7 +45,7 @@
 - (void) populateFields{
 	NSFileManager *manager = [NSFileManager defaultManager];
 	NSString *currentPath = [[NSBundle bundleForClass:[self class]]pathForResource:@"qs" ofType:@""];
-	NSString *installedPath = @"/usr/bin/qs";
+	NSString *installedPath = @"/usr/local/bin/qs";
 	if ([manager fileExistsAtPath:installedPath]) {
 		if ([manager contentsEqualAtPath:currentPath andPath:installedPath]) {
 			[toolInstallStatus setStringValue:@"Installed"];
@@ -68,66 +68,59 @@
 	}	
 }
 
-- (IBAction)installCommandLineTool:(id)sender{
-    NSFileManager *manager=[NSFileManager defaultManager];
-    NSString *toolPath=[[NSBundle bundleForClass:[self class]]pathForResource:@"qs" ofType:@""];
-    if ([manager fileExistsAtPath:@"/usr/bin/qs"])
-		
-		NSLog(@"%@", toolPath);    
-    
-    OSStatus myStatus;
-    AuthorizationFlags myFlags = kAuthorizationFlagDefaults;                //1
-    AuthorizationRef myAuthorizationRef;             //2
-    
-    myStatus = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment,             //3
-                                   myFlags, &myAuthorizationRef);               //4
-    if (myStatus != errAuthorizationSuccess)
-        return;// myStatus;
-        
-        do 
-        {
-        {
-            AuthorizationItem myItems = {kAuthorizationRightExecute, 0,             //5
-                NULL, 0};                //6
-            AuthorizationRights myRights = {1, &myItems};            //7
-            
-            myFlags = kAuthorizationFlagDefaults |           //8
-                kAuthorizationFlagInteractionAllowed |           //9
-                kAuthorizationFlagPreAuthorize |         //10
-                kAuthorizationFlagExtendRights;         //11
-            myStatus = AuthorizationCopyRights (myAuthorizationRef,                     &myRights, NULL, myFlags, NULL );           //12
-        }
-            
-            if (myStatus != errAuthorizationSuccess) break;
-            
-            {
-                char myToolPath[] = "/bin/cp";
-                char *myArguments[] = {(char *)[toolPath UTF8String],"/usr/bin", NULL };
-                FILE *myCommunicationsPipe = NULL;
-                char myReadBuffer[128];
-                
-                myFlags = kAuthorizationFlagDefaults;             //13
-                myStatus = AuthorizationExecuteWithPrivileges           //14
-                    (myAuthorizationRef, myToolPath, myFlags, myArguments,          //15
-                     &myCommunicationsPipe);         //16
-                
-                if (myStatus == errAuthorizationSuccess)
-                    for(;;)
-                    {
-                        int bytesRead = read (fileno (myCommunicationsPipe),
-                                              myReadBuffer, sizeof (myReadBuffer));
-                        if (bytesRead < 1) break;
-                        write (fileno (stdout), myReadBuffer, bytesRead);
-                    }
-            }
-        } while (0);
-            
-            AuthorizationFree (myAuthorizationRef, kAuthorizationFlagDefaults);                //17
-            
-            // if (myStatus) printf("Status: %i\n", myStatus);
-            return ;//myStatus;
-}
+- (IBAction)installCommandLineTool:(id)sender
+{
+    NSString *installPath = @"/usr/local/bin";
+    NSString *toolName = @"qs";
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSString *toolPath = [[NSBundle bundleForClass:[self class]] pathForResource:toolName ofType:@""];
+    if ([manager isWritableFileAtPath:installPath]) {
+        NSString *qstool = [installPath stringByAppendingPathComponent:toolName];
+        [manager copyItemAtPath:toolPath toPath:qstool error:nil];
+        return;
+    }
 
+    OSStatus myStatus;
+    AuthorizationFlags myFlags = kAuthorizationFlagDefaults;
+    AuthorizationRef myAuthorizationRef;
+    myStatus = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, myFlags, &myAuthorizationRef);
+    if (myStatus != errAuthorizationSuccess) {
+        return;
+    }
+    
+    do {
+        AuthorizationItem myItems = {kAuthorizationRightExecute, 0, NULL, 0};
+        AuthorizationRights myRights = {1, &myItems};
+        myFlags = kAuthorizationFlagDefaults |
+            kAuthorizationFlagInteractionAllowed |
+            kAuthorizationFlagPreAuthorize |
+            kAuthorizationFlagExtendRights;
+        myStatus = AuthorizationCopyRights(myAuthorizationRef, &myRights, NULL, myFlags, NULL);
+        
+        if (myStatus != errAuthorizationSuccess) break;
+        
+        char *mkdirArgs[] = {"-p", (char *)[installPath UTF8String], NULL};
+        AuthorizationExecuteWithPrivileges(myAuthorizationRef, "/bin/mkdir", kAuthorizationFlagDefaults, mkdirArgs, NULL);
+        char *myArguments[] = {(char *)[toolPath UTF8String], (char *)[installPath UTF8String], NULL};
+        char myReadBuffer[128];
+        
+        myFlags = kAuthorizationFlagDefaults;
+        FILE *myCommunicationsPipe = NULL;
+        myStatus = AuthorizationExecuteWithPrivileges(myAuthorizationRef, "/bin/cp", myFlags, myArguments, &myCommunicationsPipe);
+
+        if (myStatus == errAuthorizationSuccess)
+            for(;;)
+            {
+                ssize_t bytesRead = read (fileno (myCommunicationsPipe),
+                                      myReadBuffer, sizeof (myReadBuffer));
+                if (bytesRead < 1) break;
+                write (fileno (stdout), myReadBuffer, bytesRead);
+            }
+    } while (0);
+            
+            AuthorizationFree (myAuthorizationRef, kAuthorizationFlagDefaults);
+            return;
+}
 
 @end
 

--- a/qs.m
+++ b/qs.m
@@ -36,7 +36,7 @@ int main (int argc, const char * argv[]) {
 		[proxy handleArguments:[args objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, [args count]-1)]] input:input directory:directory];
 		
     }else{	
-		fprintf(stderr,"Unable to connect to Quicksilver\n");
+		fprintf(stderr,"Unable to connect to Quicksilver.\nMake sure the Command Line Tool plug-in is enabled.\n");
 		return 1;
     }    
     


### PR DESCRIPTION
It goes into `/usr/local/bin` now, where it should have always been.

Also
- if you already have permission to write there (as most Homebrew users will), it doesn’t ask for root access
- if `/usr/local/bin` doesn’t exist, it gets created
- some messages are more detailed now

fixes quicksilver/Quicksilver#2095
